### PR TITLE
Fix choices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 *.egg-info
 *.egg
 build

--- a/django_utils/choices.py
+++ b/django_utils/choices.py
@@ -230,7 +230,7 @@ class Choices(six.with_metaclass(ChoicesMeta)):
     ...     a = Choice()
     >>> choices = ChoiceTest()
     >>> choices.choices.items()
-    [(0, <Choice[3]:a>)]
+    [(0, 'a')]
     >>> choices.a
     0
     >>> choices.choices['a']

--- a/django_utils/choices.py
+++ b/django_utils/choices.py
@@ -109,8 +109,8 @@ class ChoicesDict(object):
         self._by_value[value.value] = value
 
     def __iter__(self):
-        for k, v in six.iteritems(self._by_value):
-            yield k, v
+        for value, choice in six.iteritems(self._by_value):
+            yield value, choice.label
 
     def items(self):
         return list(self)


### PR DESCRIPTION
Django 1.11
Python 3.6
I had problem after running `manage.py makemigrations` this PR fixes it.

> ValueError: Cannot serialize: <Choice[1]:Monday>
> There are some values Django cannot serialize into migration files.
> For more, see https://docs.djangoproject.com/en/1.11/topics/migrations/#migration-serializing

In my case it was:
```
> list(DAYS.choices)
> [(0, <Choice[1]:Monday>), (1, <Choice[2]:Tuesday>), (2, <Choice[3]:Wednesday>), (3, <Choice[4]:Thursday>), (4, <Choice[5]:Friday>), (5, <Choice[6]:Saturday>), (6, <Choice[7]:Sunday>)]
```
Django do not allow second value to be custom class ([Source](https://github.com/django/django/blob/master/django/db/migrations/serializer.py#L367))

Btw. Why use custom `ChoicesDict` instead of simple list of tuples?