### PR TITLE
fix choices bug on makemigrations

### DIFF
--- a/django_utils/choices.py
+++ b/django_utils/choices.py
@@ -79,13 +79,12 @@ To reference these properties:
     SomeModel.create(enum=SomeModel.Enum.Spam)
 
 '''
-import six
 import collections
-from django.utils import deconstruct
+
+import six
 
 
 class ChoicesDict(object):
-
     '''The choices dict is an object that stores a sorted representation of
     the values by key and database value'''
 
@@ -123,9 +122,7 @@ class ChoicesDict(object):
         return six.text_type(self._by_key)
 
 
-@deconstruct.deconstructible
 class Choice(object):
-
     '''The choice object has an optional label and value. If the value is not
     given an autoincrementing id (starting from 1) will be used
 
@@ -149,6 +146,11 @@ class Choice(object):
         self.value = value
         self.label = label
         self.order = Choice.order
+
+    def __eq__(self, other):
+        if not isinstance(other, Choice):
+            return False
+        return self.value == other.value and self.label == self.label
 
     def __repr__(self):
         repr_ = (six.text_type('<%s[%d]:%s>') % (
@@ -176,9 +178,15 @@ class Choice(object):
         elif six.PY3:
             return six.text_type(label)
 
+    def deconstruct(self):
+        return (
+            '{}.{}'.format(self.__class__.__module__, self.__class__.__name__),
+            (self.value, self.label),
+            {},
+        )
+
 
 class ChoicesMeta(type):
-
     '''The choices metaclass is where all the magic happens, this
     automatically creates a ChoicesDict to get a sorted list of keys and
     values'''
@@ -213,7 +221,6 @@ class ChoicesMeta(type):
 
 
 class Choices(six.with_metaclass(ChoicesMeta)):
-
     '''The choices class is what you should inherit in your Django models
 
     >>> choices = Choices()


### PR DESCRIPTION
We need own `deconstruct` method, because decorator isn't enough as I wrote  in #2.